### PR TITLE
chore: add rust-vs-c benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added benchmarks and dependenciesfor cross-language hashing
+
 ## [v0.2.0] - 2024-11-20
 
 - Removed custom error type `ChibiHashError`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,18 @@ categories = ["algorithms"]
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 
+[build-dependencies]
+cc = "1.2.1"
+
+[profile.bench]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+
 [[bench]]
 name = "bench"
+harness = false
+
+[[bench]]
+name = "rust_vs_c"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [build-dependencies]
 cc = "1.2.1"
 
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+
 [profile.bench]
 opt-level = 3
 lto = "thin"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all test clean fmt bench
+.PHONY: all test clean fmt bench bench-cross-lang
 
-all: clean fmt test bench
+all: clean fmt test bench bench-cross-lang
 
 fmt:
 	cargo fmt
@@ -12,7 +12,10 @@ clean:
 	cargo clean
 
 bench:
-	cargo bench
+	RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench --bench bench
+
+bench-cross-lang:
+	RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench --bench rust_vs_c
 
 lint:
 	cargo clippy -- -D warnings

--- a/benches/rust_vs_c.rs
+++ b/benches/rust_vs_c.rs
@@ -1,0 +1,121 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::ffi::c_void;
+
+// FFI declaration for the C implementation
+extern "C" {
+    fn chibihash64(key: *const c_void, len: isize, seed: u64) -> u64;
+}
+
+fn bench_cross_language(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rust_vs_c");
+    
+    // Test different input patterns
+    let test_cases = vec![
+        ("zeros", vec![0u8; 1024]),
+        ("ones", vec![1u8; 1024]),
+        ("alternating", (0..1024).map(|i| (i % 2) as u8).collect()),
+        ("incremental", (0..1024).map(|i| (i % 256) as u8).collect()),
+        ("random", {
+            let mut v = vec![0u8; 1024];
+            for i in 0..1024 {
+                v[i] = ((i * 7 + 13) % 256) as u8;
+            }
+            v
+        }),
+    ];
+
+    // Test different sizes to see where performance characteristics differ
+    let sizes = [8, 16, 32, 64, 128, 256, 512, 1024];
+
+    for (pattern_name, pattern) in test_cases {
+        for size in sizes.iter() {
+            let input = &pattern[..*size];
+            
+            // Benchmark Rust implementation
+            group.bench_with_input(
+                BenchmarkId::new(format!("rust_{}", pattern_name), size),
+                &input,
+                |b, input| {
+                    b.iter(|| {
+                        black_box(chibihash::chibi_hash64(
+                            black_box(input),
+                            black_box(0)
+                        ))
+                    })
+                },
+            );
+
+            // Benchmark C implementation
+            group.bench_with_input(
+                BenchmarkId::new(format!("c_{}", pattern_name), size),
+                &input,
+                |b, input| {
+                    b.iter(|| unsafe {
+                        black_box(chibihash64(
+                            black_box(input.as_ptr() as *const c_void),
+                            black_box(input.len() as isize),
+                            black_box(0)
+                        ))
+                    })
+                },
+            );
+        }
+    }
+
+    // Test alignment sensitivity
+    let aligned_data = vec![0u8; 1024];
+    let mut unaligned_data = vec![0u8; 1025];
+    unaligned_data.remove(0); // Create unaligned slice
+
+    for size in [32, 64, 128, 256].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("rust_aligned", size),
+            &aligned_data[..*size],
+            |b, input| {
+                b.iter(|| black_box(chibihash::chibi_hash64(black_box(input), 0)))
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("rust_unaligned", size),
+            &unaligned_data[..*size],
+            |b, input| {
+                b.iter(|| black_box(chibihash::chibi_hash64(black_box(input), 0)))
+            },
+        );
+
+        // Same for C implementation
+        group.bench_with_input(
+            BenchmarkId::new("c_aligned", size),
+            &aligned_data[..*size],
+            |b, input| unsafe {
+                b.iter(|| {
+                    black_box(chibihash64(
+                        black_box(input.as_ptr() as *const c_void),
+                        black_box(input.len() as isize),
+                        0
+                    ))
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("c_unaligned", size),
+            &unaligned_data[..*size],
+            |b, input| unsafe {
+                b.iter(|| {
+                    black_box(chibihash64(
+                        black_box(input.as_ptr() as *const c_void),
+                        black_box(input.len() as isize),
+                        0
+                    ))
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cross_language);
+criterion_main!(benches);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    cc::Build::new()
+        .file("csrc/chibihash.c")
+        .opt_level(3)
+        .flag("-march=native")
+        .compile("chibihash");
+    println!("cargo:rerun-if-changed=csrc/chibihash.h");
+    println!("cargo:rerun-if-changed=csrc/chibihash.c");
+}

--- a/csrc/chibihash.c
+++ b/csrc/chibihash.c
@@ -1,0 +1,72 @@
+// small, fast 64 bit hash function.
+//
+// https://github.com/N-R-K/ChibiHash
+// https://nrk.neocities.org/articles/chibihash
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, please refer to <https://unlicense.org/>
+
+#include <stdint.h>
+#include <stddef.h>
+#include "chibihash.h"
+
+static inline uint64_t
+chibihash64__load64le(const uint8_t *p)
+{
+	return (uint64_t)p[0] <<  0 | (uint64_t)p[1] <<  8 |
+	       (uint64_t)p[2] << 16 | (uint64_t)p[3] << 24 |
+	       (uint64_t)p[4] << 32 | (uint64_t)p[5] << 40 |
+	       (uint64_t)p[6] << 48 | (uint64_t)p[7] << 56;
+}
+
+uint64_t
+chibihash64(const void *keyIn, ptrdiff_t len, uint64_t seed)
+{
+	const uint8_t *k = (const uint8_t *)keyIn;
+	ptrdiff_t l = len;
+
+	const uint64_t P1 = UINT64_C(0x2B7E151628AED2A5);
+	const uint64_t P2 = UINT64_C(0x9E3793492EEDC3F7);
+	const uint64_t P3 = UINT64_C(0x3243F6A8885A308D);
+
+	uint64_t h[4] = { P1, P2, P3, seed };
+
+	for (; l >= 32; l -= 32) {
+		for (int i = 0; i < 4; ++i, k += 8) {
+			uint64_t lane = chibihash64__load64le(k);
+			h[i] ^= lane;
+			h[i] *= P1;
+			h[(i+1)&3] ^= ((lane << 40) | (lane >> 24));
+		}
+	}
+
+	h[0] += ((uint64_t)len << 32) | ((uint64_t)len >> 32);
+	if (l & 1) {
+		h[0] ^= k[0];
+		--l, ++k;
+	}
+	h[0] *= P2; h[0] ^= h[0] >> 31;
+
+	for (int i = 1; l >= 8; l -= 8, k += 8, ++i) {
+		h[i] ^= chibihash64__load64le(k);
+		h[i] *= P2; h[i] ^= h[i] >> 31;
+	}
+
+	for (int i = 0; l > 0; l -= 2, k += 2, ++i) {
+		h[i] ^= (k[0] | ((uint64_t)k[1] << 8));
+		h[i] *= P3; h[i] ^= h[i] >> 31;
+	}
+
+	uint64_t x = seed;
+	x ^= h[0] * ((h[2] >> 32)|1);
+	x ^= h[1] * ((h[3] >> 32)|1);
+	x ^= h[2] * ((h[0] >> 32)|1);
+	x ^= h[3] * ((h[1] >> 32)|1);
+
+	// moremur: https://mostlymangling.blogspot.com/2019/12/stronger-better-morer-moremur-better.html
+	x ^= x >> 27; x *= UINT64_C(0x3C79AC492BA7B653);
+	x ^= x >> 33; x *= UINT64_C(0x1C69B3F74AC4AE35);
+	x ^= x >> 27;
+
+	return x;
+}

--- a/csrc/chibihash.h
+++ b/csrc/chibihash.h
@@ -1,0 +1,18 @@
+// small, fast 64 bit hash function.
+//
+// https://github.com/N-R-K/ChibiHash
+// https://nrk.neocities.org/articles/chibihash
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, please refer to <https://unlicense.org/>
+
+#ifndef CHIBIHASH_H
+#define CHIBIHASH_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// Remove static inline and expose the function
+uint64_t chibihash64(const void *keyIn, ptrdiff_t len, uint64_t seed);
+
+#endif


### PR DESCRIPTION
Continues from https://github.com/N-R-K/ChibiHash/issues/2#issuecomment-2491133967

Changes:

- Add original C implementation to the repository
- Add bench and build files to create similar test cases to run them in C and Rust
- Create comparison report

The test cases here aim to test the following, to see if there's major compiler differences:

- Memory access patterns (zeros, ones, alternating, incremental, random)
- Alignment sensitivity: aligned/unaligned memory access
- Size: variations for input data
