### PR TITLE
chore: use latest hashbrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added benchmarks
 - Released a crate
 
-[Unreleased]: https://github.com/thevilledev/ChibiHash-rs/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/thevilledev/ChibiHash-rs/compare/v0.3.1...HEAD
+[v0.3.1]: https://github.com/thevilledev/ChibiHash-rs/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/thevilledev/ChibiHash-rs/compare/v0.2.2...v0.3.0
 [v0.2.2]: https://github.com/thevilledev/ChibiHash-rs/compare/v0.2.1...v0.2.2
 [v0.2.1]: https://github.com/thevilledev/ChibiHash-rs/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.1] - 2024-11-26
+
+- Fixed `hashbrown` version
+
 ## [v0.3.0] - 2024-11-26
 
 - Added `no-std` support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "chibihash"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 authors = ["Ville Vesilehto <ville@vesilehto.fi>"]
-description = "A Rust implementation of the ChibiHash algorithm"
+description = "Rust implementation of the ChibiHash hash function"
 repository = "https://github.com/thevilledev/ChibiHash-rs"
 documentation = "https://docs.rs/chibihash"
 keywords = ["hash", "chibihash", "fast-hash", "non-cryptographic"]
 categories = ["algorithms", "no-std"]
 
 [dependencies.hashbrown]
-version = "0.15.0"
+version = "0.15.2"
 default-features = false
 
 [dev-dependencies]


### PR DESCRIPTION
- Use latest `hashbrown` version due to interesting fixes between v0.15.0 and v0.15.2 - won't expect a huge difference but still
- Prep release v0.3.1
- Update crate description