### PR TITLE
Declare no_std when not std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 // Default version is `v1` to ensure backwards compatibility
 pub use v1::{chibi_hash64, ChibiHashMap, ChibiHashSet, ChibiHasher, StreamingChibiHasher};
 

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -322,6 +322,9 @@ impl Hasher for StreamingChibiHasher {
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "std"))]
+    use alloc::string::{String, ToString};
+
     // Keep only internal implementation tests here
     #[test]
     fn test_load_u64_le() {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -333,6 +333,9 @@ fn load_u32_le(bytes: &[u8]) -> u64 {
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "std"))]
+    use alloc::string::{String, ToString};
+
     // Keep only internal implementation tests here
     #[test]
     fn test_load_u64_le() {


### PR DESCRIPTION
no_std compatibility was lost with https://github.com/thevilledev/ChibiHash-rs/commit/ca8b1f570a4036e692e3b8c41945935711e7693a

This restores it.