### PR TITLE
chore: bump cargo version to v0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chibihash"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT"
 authors = ["Ville Vesilehto <ville@vesilehto.fi>"]


### PR DESCRIPTION
Forgot from #20 