### PR TITLE
chore(bench): deprecations for criterion

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,8 @@
 // Benchmark the `v1` version of the algorithm
 
 use chibihash::v1::{chibi_hash64, StreamingChibiHasher};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 
 fn bench_sizes(c: &mut Criterion) {
     let mut group = c.benchmark_group("input_sizes");

--- a/benches/bench_v2.rs
+++ b/benches/bench_v2.rs
@@ -1,7 +1,8 @@
 // Benchmark the `v2` version of the algorithm
 
 use chibihash::v2::{chibi_hash64, StreamingChibiHasher};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 
 fn bench_sizes(c: &mut Criterion) {
     let mut group = c.benchmark_group("v2_input_sizes");

--- a/benches/rust_vs_c.rs
+++ b/benches/rust_vs_c.rs
@@ -1,9 +1,11 @@
 // Benchmark the `v1` version of the algorithm
 
 #[cfg(feature = "ffi")]
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "ffi")]
 use std::ffi::c_void;
+#[cfg(feature = "ffi")]
+use std::hint::black_box;
 
 // FFI declaration for the C implementation
 #[cfg(feature = "ffi")]


### PR DESCRIPTION
`criterion::black_box` was deprecated in favor of `std::hint::black_box()` which is now available in the standard library.